### PR TITLE
修复书签链接跳转到锚点时滚动过多的问题

### DIFF
--- a/css/core/global.css
+++ b/css/core/global.css
@@ -181,6 +181,10 @@ a:hover {
   --header-height: clamp(40px, 8vh, 100vh);
 }
 
+html {
+  scroll-padding-top: calc(var(--header-height) + 20px);
+}
+
 header,
 nav.header-nav {
   width: 100%;


### PR DESCRIPTION
1. 修复书签链接跳转到锚点时滚动过多的问题