### PR TITLE
fix(html): 修正锚点链接使用方法

### DIFF
--- a/html/code/minecraft/spyglass-usage.html
+++ b/html/code/minecraft/spyglass-usage.html
@@ -78,17 +78,17 @@
     </div>
 
     <div class="left card-1">
-      <h2 class="center">Spyglass 插件<a name="Spyglass插件"></a></h2>
+      <h2 class="center" id="Spyglass插件">Spyglass 插件</h2>
 
-      <h3>安装 Spyglass<a name="安装Spyglass"></a></h3>
+      <h3 id="安装Spyglass">安装 Spyglass</h3>
 
       <p>
         在 <em>VS Code</em> <strong>插件页面</strong>搜索 <code>Datapack Helper Plus by Spyglass</code> 进行安装
       </p>
 
-      <h3>配置 Spyglass<a name="配置Spyglass"></a></h3>
+      <h3 id="配置Spyglass">配置 Spyglass</h3>
 
-      <h4>VS Code 插件设置<a name="VSCode插件设置"></a></h4>
+      <h4 id="VSCode插件设置">VS Code 插件设置</h4>
 
       <p><em>VS Cdoe</em> 插件设置中可以调整: </p>
       <ul>
@@ -108,7 +108,7 @@
         </li>
       </ul>
 
-      <h4>配置文件<a name="配置文件"></a></h4>
+      <h4 id="配置文件">配置文件</h4>
 
       <p><a href="https://spyglassmc.com/user/config.html">Spyglass 官方配置文件说明</a></p>
       <p>
@@ -331,7 +331,7 @@
 </pre>
           </code>
 
-      <h5>配置文件示例<a name="配置文件示例"></a></h5>
+      <h5 id="配置文件示例">配置文件示例</h5>
       <code>
 <pre>
 {

--- a/html/ks-game.html
+++ b/html/ks-game.html
@@ -54,7 +54,7 @@
 
     <section class="left card-1">
       <div>
-        <h2>介绍<a name="介绍"></a></h2>
+        <h2 id="介绍">介绍</h2>
         <p>
           一群 <em>Minecraft</em> <strong>整合包/地图</strong> 玩家, 不定期开坑整合包/地图。
         </p>
@@ -72,7 +72,7 @@
 
     <section class="left card-1">
       <div>
-        <h2>如何加入<a name="加入"></a></h2>
+        <h2 id="加入">如何加入</h2>
         <p>
           <strong>Bilibili</strong>: <a href="https://space.bilibili.com/3493268878789144" target="_blank">侃生电核2333</a>私信说明
           <br>

--- a/html/ks-server.html
+++ b/html/ks-server.html
@@ -60,7 +60,7 @@
 
     <section class="left card-1">
       <div>
-        <h2>介绍<a name="介绍"></a></h2>
+        <h2 id="介绍">介绍</h2>
         <p>
           一个 <strong>开在自己电脑上</strong> 时不时就会掉线重启的服务端, 还有可能被<a href="ks-game.html">Ks-game</a>影响。
         </p>
@@ -93,7 +93,7 @@
 
     <section class="left card-1">
       <div>
-        <h2>插件/模组<a name="插件/模组"></a></h2>
+        <h2 id="插件/模组">插件/模组</h2>
         <p>
           服务端现为 <em>Java</em> 版 <em>1.21fabric</em> , 使用 <em>MCDReforged</em> 代理, 并使用 <em>Velocity</em> 建立服务器联通
         </p>
@@ -157,7 +157,7 @@
 
     <section class="left card-1">
       <div>
-        <h2>规则<a name="规则"></a></h2>
+        <h2 id="规则">规则</h2>
         <h3>客户端功能</h3>
         <p>
           仅服主 <strong>允许的客户端功能</strong> 可以使用, 任何没有经过许可的客户端功能需要 <strong>向服主询问</strong> 。
@@ -195,7 +195,7 @@
 
     <section class="left card-1">
       <div>
-        <h2>如何加入<a name="加入"></a></h2>
+        <h2 id="加入">如何加入</h2>
         <p>
           可以通过<a href="https://chat.xiaoheihe.cn/ifzav62l" target="_blank">chat.xiaoheihe.cn/ifzav62l</a>加入服务器的
           <strong>黑盒语音房间</strong> ,

--- a/html/useful-minecraftresources.html
+++ b/html/useful-minecraftresources.html
@@ -68,14 +68,14 @@
     </div>
     <section class="left card-1">
       <div>
-        <h2>模组<a name="模组"></a></h2>
+        <h2 id="模组">模组</h2>
         <p>
           列表基于 <em>Minecraft 1.21 fabric</em> 列出
           <br>
           仅提供 <strong>客户端功能类</strong> 模组, 对于其中模组的前置库, 请自行搜索安装
         </p>
         <div>
-          <h3>辅助模组<a name="辅助模组"></a></h3>
+          <h3 id="辅助模组">辅助模组</h3>
           <table>
             <tr>
               <th>模组名</th>
@@ -233,7 +233,7 @@
         </div>
 
         <div>
-          <h3>机制更改模组<a name="机制更改模组"></a></h3>
+          <h3 id="机制更改模组">机制更改模组</h3>
           <table>
             <tr>
               <th>模组名</th>
@@ -269,7 +269,7 @@
         </div>
 
         <div>
-          <h3>优化模组<a name="优化模组"></a></h3>
+          <h3 id="优化模组">优化模组</h3>
           <table>
             <tr>
               <th>模组名</th>
@@ -330,7 +330,7 @@
 
     <section class="left card-1">
       <div>
-        <h2>资源包<a name="资源包"></a></h2>
+        <h2 id="资源包">资源包</h2>
         <table>
           <tr>
             <th>资源包</th>
@@ -354,7 +354,7 @@
 
     <section class="left card-1">
       <div>
-        <h2>光影<a name="光影"></a></h2>
+        <h2 id="光影">光影</h2>
         <table>
           <tr>
             <th>光影</th>


### PR DESCRIPTION
1. 将所有使用a元素name属性的锚点链接改为直接指定标题元素的id属性 Closes #35