### PR TITLE
feat(web): 重新为页面分组并添加组导航页

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@
 
 有关一起联机玩 *Minecarft* 的内容
 
-- [Ks-server](https://www.ksdh.dpdns.org/html/ks-server.html) : 生电 服......吗? 
-- [Ks-game](https://www.ksdh.dpdns.org/html/ks-game.html) : 跟朋友联机玩 *Minecraft* 整合包
+- [Ks-server](https://www.ksdh.dpdns.org/html/server/ks-server.html) : 生电 服......吗? 
+- [Ks-game](https://www.ksdh.dpdns.org/html/server/ks-game.html) : 跟朋友联机玩 *Minecraft* 整合包
 
 ### 资源
 
 有关 *Minecraft* 的资源
 
-- [实用资源](https://www.ksdh.dpdns.org/html/useful-minecraftresources.html) : *侃生电核2333* 用到的 **模组, 资源包, 光影**等
-- [实用网站链接](https://www.ksdh.dpdns.org/html/useful-links.html) : *Minecraft* 好用的资源工具网站汇总
+- [实用资源](https://www.ksdh.dpdns.org/html/minecraft-resources/useful-minecraft-resources.html) : *侃生电核2333* 用到的 **模组, 资源包, 光影**等
+- [实用网站链接](https://www.ksdh.dpdns.org/html/minecraft-resources/useful-minecraft-links.html) : *Minecraft* 好用的资源工具网站汇总
 
 更多内容还在开发......

--- a/css/core/global.css
+++ b/css/core/global.css
@@ -447,7 +447,8 @@ aside.sidebar-nav ul {
 /* 卡片 */
 .card-1,
 .card-2,
-.card-3 {
+.card-3,
+.card-4 {
   padding: 30px;
   max-width: 1000px;
 
@@ -460,7 +461,8 @@ aside.sidebar-nav ul {
   background-color: var(--background-color-card-level1);
 }
 
-.card-3 {
+.card-3,
+.card-4 {
   background-color: var(--background-color-botton);
 }
 
@@ -469,7 +471,8 @@ aside.sidebar-nav ul {
   margin: 20px auto;
 }
 
-.card-2-parent {
+.card-2-parent,
+.card-4-parent {
   width: 85%;
   gap: 20px;
   /* 设置两个卡片之间的间距 */
@@ -477,7 +480,14 @@ aside.sidebar-nav ul {
   /* 将容器设置为Flex布局 */
   margin: 40px auto;
   max-width: 1000px;
+}
+
+.card-2-parent {
   flex-direction: row;
+}
+
+.card-4-parent {
+  flex-direction: column;
 }
 
 /* 移动端适配 */

--- a/html/about-host.html
+++ b/html/about-host.html
@@ -7,9 +7,9 @@
   <meta name="keywords" content="ksdh2333, 侃生电核2333">
   <meta name="description" content="关于侃生电核2333">
   <meta name="author" content="侃生电核2333">
-  <base target="_self">
-  <link rel="icon" href="../resources/img/avatar-ksdh2333.png">
-  <link rel="stylesheet" href="../css/core/global.css">
+  <base target="_self" href="../">
+  <link rel="icon" href="resources/img/avatar-ksdh2333.png">
+  <link rel="stylesheet" href="css/core/global.css">
   <title>关于站主 - 侃生电核2333</title>
 </head>
 
@@ -17,7 +17,7 @@
   <header>
     <nav class="header-nav">
       <div>
-        <a href="../index.html" title="首页"><img src="../resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
         <div>
           <strong>侃生电核2333</strong>
           <p>
@@ -27,20 +27,19 @@
       </div>
       <div>
         <ul>
-          <li><a href="../index.html">首页</a></li>
-          <li><a href="ks-server.html">生电服</a></li>
-          <li><a href="ks-game.html">游戏服</a></li>
-          <li><a href="useful-minecraftresources.html">实用资源</a></li>
-          <li><a href="useful-links.html">实用网页</a></li>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
         </ul>
       </div>
-      <a href="about-host.html" id="about-host">关于站主</a>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
     </nav>
   </header>
 
   <main>
     <div class="center card-1">
-      <img src="../resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像">
+      <img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像">
       <h1>侃生电核2333</h1>
       <strong>ksdh2333</strong>
     </div>
@@ -77,21 +76,21 @@
 
     <div class="card-2-parent">
       <a href="https://space.bilibili.com/3493268878789144" target="_blank" class="center card-2 floating">
-        <img src="../resources/img/bilibili-icon.png" width="64" height="64" alt="Bilibili图标">
+        <img src="resources/img/bilibili-icon.png" width="64" height="64" alt="Bilibili图标">
         <h2>Bilibili账号</h2>
         <p>
           点击查看空间&gt;&gt;
         </p>
       </a>
       <a href="https://github.com/ksdh2333/" target="_blank" class="center card-2 floating">
-        <img src="../resources/img/github-icon.png" width="64" height="64" alt="Github图标">
+        <img src="resources/img/github-icon.png" width="64" height="64" alt="Github图标">
         <h2>Github账号</h2>
         <p>
           点击查看账号主页&gt;&gt;
         </p>
       </a>
       <a href="https://afdian.com/a/ksdh2333/" target="_blank" class="center card-2 floating">
-        <img src="../resources/img/afdian-icon.png" width="64" height="64" alt="爱发电图标">
+        <img src="resources/img/afdian-icon.png" width="64" height="64" alt="爱发电图标">
         <h2>爱发电账号</h2>
         <p>
           点击查看爱发电主页&gt;&gt;

--- a/html/knowledge-base/knowledge-base-nav.html
+++ b/html/knowledge-base/knowledge-base-nav.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="zh-Hans-CN">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="keywords" content="Minecraft, 知识库">
+  <meta name="description" content="个人知识库">
+  <meta name="author" content="侃生电核2333">
+  <base target="_self" href="../../">
+  <link rel="icon" href="resources/img/avatar-ksdh2333.png">
+  <link rel="stylesheet" href="css/core/global.css">
+  <title>知识库 - 侃生电核2333</title>
+</head>
+
+<body>
+  <header>
+    <nav class="header-nav">
+      <div>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <div>
+          <strong>侃生电核2333</strong>
+          <p>
+            一个Minecraft玩家
+          </p>
+        </div>
+      </div>
+      <div>
+        <ul>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
+        </ul>
+      </div>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
+    </nav>
+  </header>
+
+  <main>
+    <div class="center card-1">
+
+      <h1>知识库</h1>
+
+      <p>
+        你这知识保熟吗?
+      </p>
+      <div class="card-4-parent">
+        <a href="html/knowledge-base/spyglass-usage/spyglass-usage.html" title="Ks-server" class="left card-4 floating">
+
+          <h3>Spyglass 插件相关实用说明</h3>
+
+          <p>
+            包括插件的安装配置、命令树配置、 Mcdoc 文档的用法和语法
+            <br>
+            Spyglass (Datapack Helper Plus)是一个强大的 Minecraft 开发工具, 提供语法高亮, 智能提示等功能
+          </p>
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <hr>
+  <footer>
+    <p>
+      &copy; 2025 侃生电核2333 Minecraft实用资源
+      <br>
+      页面由 侃生电核2333 设计
+      <br>
+      网页开源项目:<a href="https://github.com/ksdh2333/ksdh2333.github.io/" target="_blank">https://github.com/ksdh2333/ksdh2333.github.io/</a>
+    </p>
+  </footer>
+</body>
+
+</html>

--- a/html/knowledge-base/spyglass-usage/spyglass-usage.html
+++ b/html/knowledge-base/spyglass-usage/spyglass-usage.html
@@ -7,10 +7,10 @@
   <meta name="keywords" content="Spyglass, SpyglassMC, Datapack, Datapack Helper Plus, DHP, 大憨批">
   <meta name="description" content="Spyglass 插件相关使用说明">
   <meta name="author" content="侃生电核2333">
-  <base target="_self">
-  <link rel="icon" href="../../../resources/img/avatar-ksdh2333.png">
-  <link rel="stylesheet" href="../../../css/core/global.css">
-  <script defer src="../../../javascript/sidebar.js"></script>
+  <base target="_self" href="../../../">
+  <link rel="icon" href="resources/img/avatar-ksdh2333.png">
+  <link rel="stylesheet" href="css/core/global.css">
+  <script defer src="javascript/sidebar.js"></script>
   <title>Spyglass 插件相关使用说明</title>
 </head>
 
@@ -18,7 +18,7 @@
   <header>
     <nav class="header-nav">
       <div>
-        <a href="../../../index.html" title="首页"><img src="../../../resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
         <div>
           <strong>侃生电核2333</strong>
           <p>
@@ -28,14 +28,13 @@
       </div>
       <div>
         <ul>
-          <li><a href="../../../index.html">首页</a></li>
-          <li><a href="../../ks-server.html">生电服</a></li>
-          <li><a href="../../ks-game.html">游戏服</a></li>
-          <li><a href="../../useful-minecraftresources.html">实用资源</a></li>
-          <li><a href="../../useful-links.html">实用网页</a></li>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
         </ul>
       </div>
-      <a href="../../about-host.html" id="about-host">关于站主</a>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
     </nav>
   </header>
 
@@ -43,100 +42,100 @@
     <nav>
       <h2>目录</h2>
       <ul>
-        <li><a href="#Spyglass插件">Spyglass 插件</a>
+        <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#Spyglass插件">Spyglass 插件</a>
           <ul>
-            <li><a href="#安装Spyglass">安装 Spyglass</a></li>
-            <li><a href="#配置Spyglass">配置 Spyglass</a>
+            <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#安装Spyglass">安装 Spyglass</a></li>
+            <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#配置Spyglass">配置 Spyglass</a>
               <ul>
-                <li><a href="#VSCode插件设置">VSCode 插件设置</a></li>
-                <li><a href="#配置文件">配置文件</a>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#VSCode插件设置">VSCode 插件设置</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#配置文件">配置文件</a>
                   <ul>
-                    <li><a href="#env-配置">env 配置</a></li>
-                    <li><a href="#format-配置">format 配置</a></li>
-                    <li><a href="#lint-配置">lint 配置</a></li>
-                    <li><a href="#snippet-配置">snippet 配置</a></li>
-                    <li><a href="#配置文件示例">配置文件示例</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#env-配置">env 配置</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#format-配置">format 配置</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#lint-配置">lint 配置</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#snippet-配置">snippet 配置</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#配置文件示例">配置文件示例</a></li>
                   </ul>
                 </li>
               </ul>
             </li>
           </ul>
         </li>
-        <li><a href="#命令树">命令树</a>
+        <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#命令树">命令树</a>
           <ul>
-            <li><a href="#命令树的结构">命令树的结构</a></li>
-            <li><a href="#自定义命令树">自定义命令树</a>
+            <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#命令树的结构">命令树的结构</a></li>
+            <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#自定义命令树">自定义命令树</a>
               <ul>
-                <li><a href="#配置自定义命令树">配置自定义命令树</a></li>
-                <li><a href="#生成命令树文件">生成命令树文件</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#配置自定义命令树">配置自定义命令树</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#生成命令树文件">生成命令树文件</a></li>
               </ul>
             </li>
           </ul>
         </li>
-        <li><a href="#mcdoc的使用">Mcdoc 的使用</a>
+        <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc的使用">Mcdoc 的使用</a>
           <ul>
-            <li><a href="#mcdoc基本语法">基本语法</a>
+            <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc基本语法">基本语法</a>
               <ul>
-                <li><a href="#mcdoc注释">注释</a>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc注释">注释</a>
                   <ul>
-                    <li><a href="#mcdoc普通注释">普通注释</a></li>
-                    <li><a href="#mcdocdoc注释">Doc注释</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc普通注释">普通注释</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdocdoc注释">Doc注释</a></li>
                   </ul>
                 </li>
-                <li><a href="#mcdoc类型化数字">类型化数字</a></li>
-                <li><a href="#mcdoc数字范围">数字范围</a></li>
-                <li><a href="#mcdoc字符串语法">字符串语法</a></li>
-                <li><a href="#mcdoc路径">路径</a></li>
-                <li><a href="#mcdoc标识符">标识符</a></li>
-                <li><a href="#mcdoc结构体定义">结构体定义</a></li>
-                <li><a href="#mcdoc类型映射">类型映射</a></li>
-                <li><a href="#mcdoc字段的类型">字段的类型</a>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc类型化数字">类型化数字</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc数字范围">数字范围</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc字符串语法">字符串语法</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc路径">路径</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc标识符">标识符</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc结构体定义">结构体定义</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc类型映射">类型映射</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc字段的类型">字段的类型</a>
                   <ul>
-                    <li><a href="#mcdoc类型any">any 类型</a></li>
-                    <li><a href="#mcdoc类型boolean">boolean 类型</a></li>
-                    <li><a href="#mcdoc类型string">string 类型</a></li>
-                    <li><a href="#mcdoc数值类型">数值类型</a></li>
-                    <li><a href="#mcdoc字面量类型">字面量类型</a></li>
-                    <li><a href="#mcdoc原始数组类型">原始数组类型</a></li>
-                    <li><a href="#mcdoc列表类型">列表类型</a></li>
-                    <li><a href="#mcdoc元组类型">元组类型</a></li>
-                    <li><a href="#mcdoc枚举类型">枚举类型</a></li>
-                    <li><a href="#mcdoc分派器类型">分派器类型</a></li>
-                    <li><a href="#mcdoc联合类型">联合类型</a></li>
-                    <li><a href="#mcdoc类型索引">类型索引</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc类型any">any 类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc类型boolean">boolean 类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc类型string">string 类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc数值类型">数值类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc字面量类型">字面量类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc原始数组类型">原始数组类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc列表类型">列表类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc元组类型">元组类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc枚举类型">枚举类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc分派器类型">分派器类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc联合类型">联合类型</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc类型索引">类型索引</a></li>
                   </ul>
                 </li>
-                <li><a href="#mcdoc类型别名语句">类型别名语句</a></li>
-                <li><a href="#mcdoc绑定类型参数">绑定类型参数</a></li>
-                <li><a href="#mcdoc使用语句">使用语句</a></li>
-                <li><a href="#mcdoc注入">注入</a>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc类型别名语句">类型别名语句</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc绑定类型参数">绑定类型参数</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc使用语句">使用语句</a></li>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc注入">注入</a>
                   <ul>
-                    <li><a href="#mcdoc枚举注入">枚举注入</a></li>
-                    <li><a href="#mcdoc结构体注入">结构体注入</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc枚举注入">枚举注入</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc结构体注入">结构体注入</a></li>
                   </ul>
                 </li>
-                <li><a href="#mcdoc属性">属性</a>
+                <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性">属性</a>
                   <ul>
-                    <li><a href="#mcdoc属性canonical">canonical</a></li>
-                    <li><a href="#mcdoc属性color">color</a></li>
-                    <li><a href="#mcdoc属性command">command</a></li>
-                    <li><a href="#mcdoc属性deprecated">deprecated</a></li>
-                    <li><a href="#mcdoc属性dispatcher_key">dispatcher_key</a></li>
-                    <li><a href="#mcdoc属性divisible_by">divisible_by</a></li>
-                    <li><a href="#mcdoc属性entity">entity</a></li>
-                    <li><a href="#mcdoc属性game_rule">game_rule</a></li>
-                    <li><a href="#mcdoc属性id">id</a></li>
-                    <li><a href="#mcdoc属性match_regex">match_regex</a></li>
-                    <li><a href="#mcdoc属性nbt">nbt</a></li>
-                    <li><a href="#mcdoc属性nbt_path">nbt_path</a></li>
-                    <li><a href="#mcdoc属性objective">objective</a></li>
-                    <li><a href="#mcdoc属性regex_pattern">regex_pattern</a></li>
-                    <li><a href="#mcdoc属性score_holder">score_holder</a></li>
-                    <li><a href="#mcdoc属性since">since</a></li>
-                    <li><a href="#mcdoc属性tag">tag</a></li>
-                    <li><a href="#mcdoc属性team">team</a></li>
-                    <li><a href="#mcdoc属性text_component">text_component</a></li>
-                    <li><a href="#mcdoc属性until">until</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性canonical">canonical</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性color">color</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性command">command</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性deprecated">deprecated</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性dispatcher_key">dispatcher_key</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性divisible_by">divisible_by</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性entity">entity</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性game_rule">game_rule</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性id">id</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性match_regex">match_regex</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性nbt">nbt</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性nbt_path">nbt_path</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性objective">objective</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性regex_pattern">regex_pattern</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性score_holder">score_holder</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性since">since</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性tag">tag</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性team">team</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性text_component">text_component</a></li>
+                    <li><a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性until">until</a></li>
                   </ul>
                 </li>
               </ul>
@@ -159,7 +158,7 @@
         <a href="https://spyglassmc.com/" target="_blank">https://spyglassmc.com/</a>这里有 <em>Spyglass</em> 的官方文档, 提供了完整的使用说明
       </p>
       <p>
-        <a href="spyglass-usage.md" download="Spyglass插件用法.md">下载此页面的 Markdown 版本</a>
+        <a href="html/knowledge-base/spyglass-usage/spyglass-usage.md" download="Spyglass插件用法.md">下载此页面的 Markdown 版本</a>
       </p>
     </div>
 
@@ -263,7 +262,7 @@
             方块、流体和注册表列表格式未知
           </div>
           <ul>
-            <li><code>commands</code>: 自定义<strong>命令树</strong>, 命令树写法见:<a href="#命令树">命令树</a>
+            <li><code>commands</code>: 自定义<strong>命令树</strong>, 命令树写法见:<a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#命令树">命令树</a>
               <ul>
                 <li>
                   <code>path</code>: 自定义命令树<strong>路径</strong>
@@ -637,7 +636,7 @@
         可以通过 <code>spyglass.json</code> 配置文件中的 <code>mcmetaSummaryOverrides.commands</code> 选项来配置自定义命令树
       </p>
       <p>
-        见 <a href="#env-配置">env 配置</a> 下的 <code>mcmetaSummaryOverrides.commands</code> 配置项
+        见 <a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#env-配置">env 配置</a> 下的 <code>mcmetaSummaryOverrides.commands</code> 配置项
       </p>
 
       <h4 id="生成命令树文件">生成命令树文件</h4>
@@ -1397,7 +1396,7 @@ value?: Text,</code></pre>
       <p>
         使字段或联合成员仅从<strong>给定版本开始可用</strong>
         只允许正式版本(不包括快照)
-        从给定版本不可用参见 <a href="#mcdoc属性until">until</a>
+        从给定版本不可用参见 <a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性until">until</a>
       </p>
       <pre><code>struct Example1 {
    #[since="1.19"]
@@ -1443,7 +1442,7 @@ type Example2 = (
         使字段或联合成员<strong>从给定版本开始不可用</strong>
         只允许正式版本(不包括快照)
         注意给定版本不包含在该字段或成员被接受的版本范围内
-        从给定版本开始可用参见 <a href="#mcdoc属性since">since</a>
+        从给定版本开始可用参见 <a href="html/knowledge-base/spyglass-usage/spyglass-usage.html#mcdoc属性since">since</a>
       </p>
       <pre><code>struct Example1 {
    #[until="1.19"]

--- a/html/knowledge-base/spyglass-usage/spyglass-usage.md
+++ b/html/knowledge-base/spyglass-usage/spyglass-usage.md
@@ -5,7 +5,7 @@ Spyglass 插件相关使用说明
 
 <https://spyglassmc.com/> 这里有 *Spyglass* 的官方文档, 提供了完整的使用说明
 
-[查看此文档的网页版本](https://ksdh.dpdns.org/html/code/minecraft/spyglass-usage.html)
+[查看此文档的网页版本](https://ksdh.dpdns.org/html/knowledge-base/spyglass-usage/spyglass-usage.html)
 
 ---
 

--- a/html/minecraft-resources/minecraft-resources-nav.html
+++ b/html/minecraft-resources/minecraft-resources-nav.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="zh-Hans-CN">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="keywords" content="Minecraft资源, Minecraft">
+  <meta name="description" content="Minecraft资源">
+  <meta name="author" content="侃生电核2333">
+  <base target="_self" href="../../">
+  <link rel="icon" href="resources/img/avatar-ksdh2333.png">
+  <link rel="stylesheet" href="css/core/global.css">
+  <title>Minecraft资源 - 侃生电核2333</title>
+</head>
+
+<body>
+  <header>
+    <nav class="header-nav">
+      <div>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <div>
+          <strong>侃生电核2333</strong>
+          <p>
+            一个Minecraft玩家
+          </p>
+        </div>
+      </div>
+      <div>
+        <ul>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
+        </ul>
+      </div>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
+    </nav>
+  </header>
+
+  <main>
+    <div class="center card-1">
+
+      <h1>Minecraft资源</h1>
+
+      <p>
+        一些与 <em>Minecraft</em> 相关的资源
+      </p>
+      <div class="card-4-parent">
+        <a href="html/minecraft-resources/useful-minecraft-resources.html" title="Ks-server" class="card-4 floating">
+
+          <h3>实用资源</h3>
+
+          <p>
+            模组、光影、资源包
+            <br>
+            贴近原版, 提升生存、生电体验
+            <br>
+            点击查看详情&gt;&gt;
+          </p>
+        </a>
+        <a href="html/minecraft-resources/useful-minecraft-links.html" title="ks-game" class="card-4 floating">
+
+          <h3>实用网页</h3>
+
+          <p>
+            官网、Wiki、资源站、工具
+            <br>
+            值得收藏的实用网站
+            <br>
+            点击查看详情&gt;&gt;
+          </p>
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <hr>
+  <footer>
+    <p>
+      &copy; 2025 侃生电核2333 Minecraft实用资源
+      <br>
+      页面由 侃生电核2333 设计
+      <br>
+      网页开源项目:<a href="https://github.com/ksdh2333/ksdh2333.github.io/" target="_blank">https://github.com/ksdh2333/ksdh2333.github.io/</a>
+    </p>
+  </footer>
+</body>
+
+</html>

--- a/html/minecraft-resources/useful-minecraft-links.html
+++ b/html/minecraft-resources/useful-minecraft-links.html
@@ -7,9 +7,9 @@
   <meta name="keywords" content="Minecraft网站, Minecraft">
   <meta name="description" content="Minecraft实用链接">
   <meta name="author" content="侃生电核2333">
-  <base target="_self">
-  <link rel="icon" href="../resources/img/avatar-ksdh2333.png">
-  <link rel="stylesheet" href="../css/core/global.css">
+  <base target="_self" href="../../">
+  <link rel="icon" href="resources/img/avatar-ksdh2333.png">
+  <link rel="stylesheet" href="css/core/global.css">
   <title>Minecraft实用链接 - 侃生电核2333</title>
 </head>
 
@@ -17,7 +17,7 @@
   <header>
     <nav class="header-nav">
       <div>
-        <a href="../index.html" title="首页"><img src="../resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
         <div>
           <strong>侃生电核2333</strong>
           <p>
@@ -27,14 +27,13 @@
       </div>
       <div>
         <ul>
-          <li><a href="../index.html">首页</a></li>
-          <li><a href="ks-server.html">生电服</a></li>
-          <li><a href="ks-game.html">游戏服</a></li>
-          <li><a href="useful-minecraftresources.html">实用资源</a></li>
-          <li><a href="useful-links.html">实用网页</a></li>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
         </ul>
       </div>
-      <a href="about-host.html" id="about-host">关于站主</a>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
     </nav>
   </header>
 

--- a/html/minecraft-resources/useful-minecraft-resources.html
+++ b/html/minecraft-resources/useful-minecraft-resources.html
@@ -7,10 +7,10 @@
   <meta name="keywords" content="Minecraft资源包, Minecraft模组">
   <meta name="description" content="Minecraft实用资源">
   <meta name="author" content="侃生电核2333">
-  <base target="_self">
-  <link rel="icon" href="../resources/img/avatar-ksdh2333.png">
-  <link rel="stylesheet" href="../css/core/global.css">
-  <script defer src="../javascript/sidebar.js"></script>
+  <base target="_self" href="../../">
+  <link rel="icon" href="resources/img/avatar-ksdh2333.png">
+  <link rel="stylesheet" href="css/core/global.css">
+  <script defer src="javascript/sidebar.js"></script>
   <title>Minecraft实用资源 - 侃生电核2333</title>
 </head>
 
@@ -18,7 +18,7 @@
   <header>
     <nav class="header-nav">
       <div>
-        <a href="../index.html" title="首页"><img src="../resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
         <div>
           <strong>侃生电核2333</strong>
           <p>
@@ -28,14 +28,13 @@
       </div>
       <div>
         <ul>
-          <li><a href="../index.html">首页</a></li>
-          <li><a href="ks-server.html">生电服</a></li>
-          <li><a href="ks-game.html">游戏服</a></li>
-          <li><a href="useful-minecraftresources.html">实用资源</a></li>
-          <li><a href="useful-links.html">实用网页</a></li>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
         </ul>
       </div>
-      <a href="about-host.html" id="about-host">关于站主</a>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
     </nav>
   </header>
 
@@ -44,15 +43,15 @@
       <h2>导航</h2>
       <ul>
         <li>
-          <a href="#模组">模组</a>
+          <a href="html/minecraft-resources/useful-minecraft-resources.html#模组">模组</a>
           <ul>
-            <li><a href="#辅助模组">辅助模组</a></li>
-            <li><a href="#机制更改模组">机制更改模组</a></li>
-            <li><a href="#优化模组">优化模组</a></li>
+            <li><a href="html/minecraft-resources/useful-minecraft-resources.html#辅助模组">辅助模组</a></li>
+            <li><a href="html/minecraft-resources/useful-minecraft-resources.html#机制更改模组">机制更改模组</a></li>
+            <li><a href="html/minecraft-resources/useful-minecraft-resources.html#优化模组">优化模组</a></li>
           </ul>
         </li>
-        <li><a href="#资源包">资源包</a></li>
-        <li><a href="#光影">光影</a></li>
+        <li><a href="html/minecraft-resources/useful-minecraft-resources.html#资源包">资源包</a></li>
+        <li><a href="html/minecraft-resources/useful-minecraft-resources.html#光影">光影</a></li>
       </ul>
     </nav>
   </aside>
@@ -194,7 +193,7 @@
               <td>
                 提供禁止破坏脚手架、世吞挖矿助手等 <strong>客户端功能</strong>
                 <br>
-                截至网页编写时间, 该仓库中没有可用的Oh My Minecraft Client下载方式, 点击<a href="../resources/minecraft-mods/OhMyMinecraftClient-mc1.21.1-fabric-0.6.362-pull_request.jar" download="OhMyMinecraftClient-mc1.21.1-fabric-0.6.362-pull_request.jar">此处</a>以下载可用的1.21fabric Oh My Minecraft Client, 该版本仍存在bug, 请谨慎使用
+                截至网页编写时间, 该仓库中没有可用的Oh My Minecraft Client下载方式, 点击<a href="resources/minecraft-mods/OhMyMinecraftClient-mc1.21.1-fabric-0.6.362-pull_request.jar" download="OhMyMinecraftClient-mc1.21.1-fabric-0.6.362-pull_request.jar">此处</a>以下载可用的1.21fabric Oh My Minecraft Client, 该版本仍存在bug, 请谨慎使用
               </td>
             </tr>
             <tr>
@@ -374,9 +373,9 @@
           <p>
             光影配置文件 <strong>仅供参考</strong> , 站主非专业光影开发者
           </p>
-          <a href="../resources/shader-config/ComplementaryUnbound_r5.4.zip.txt" download="ComplementaryUnbound_r5.4.zip.txt">Complementary Shaders - Unbound 参考配置文件</a>
+          <a href="resources/shader-config/ComplementaryUnbound_r5.4.zip.txt" download="ComplementaryUnbound_r5.4.zip.txt">Complementary Shaders - Unbound 参考配置文件</a>
           <br>
-          <a href="../resources/shader-config/ComplementaryUnbound_r5.4 + EuphoriaPatches_1.5.2.zip.txt" download="ComplementaryUnbound_r5.4 + EuphoriaPatches_1.5.2.zip.txt">Complementary Unbound + EuphoriaPatches 参考配置文件</a>
+          <a href="resources/shader-config/ComplementaryUnbound_r5.4 + EuphoriaPatches_1.5.2.zip.txt" download="ComplementaryUnbound_r5.4 + EuphoriaPatches_1.5.2.zip.txt">Complementary Unbound + EuphoriaPatches 参考配置文件</a>
           <p>
             游戏内光影设置右上角点击 "导入", 选择下载好的配置文件即可使用参考配置文件
           </p>

--- a/html/server/ks-game.html
+++ b/html/server/ks-game.html
@@ -7,10 +7,10 @@
   <meta name="keywords" content="Ks-game, Ks服">
   <meta name="description" content="Ks-game介绍">
   <meta name="author" content="侃生电核2333">
-  <base target="_self">
-  <link rel="icon" href="../resources/img/avatar-ksdh2333.png">
-  <link rel="stylesheet" href="../css/core/global.css">
-  <script defer src="../javascript/sidebar.js"></script>
+  <base target="_self" href="../../">
+  <link rel="icon" href="resources/img/avatar-ksdh2333.png">
+  <link rel="stylesheet" href="css/core/global.css">
+  <script defer src="javascript/sidebar.js"></script>
   <title>Ks-game - 侃生电核2333</title>
 </head>
 
@@ -18,7 +18,7 @@
   <header>
     <nav class="header-nav">
       <div>
-        <a href="../index.html" title="首页"><img src="../resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
         <div>
           <strong>侃生电核2333</strong>
           <p>
@@ -28,14 +28,13 @@
       </div>
       <div>
         <ul>
-          <li><a href="../index.html">首页</a></li>
-          <li><a href="ks-server.html">生电服</a></li>
-          <li><a href="ks-game.html">游戏服</a></li>
-          <li><a href="useful-minecraftresources.html">实用资源</a></li>
-          <li><a href="useful-links.html">实用网页</a></li>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
         </ul>
       </div>
-      <a href="about-host.html" id="about-host">关于站主</a>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
     </nav>
   </header>
 
@@ -43,8 +42,8 @@
     <nav>
       <h2>导航</h2>
       <ul>
-        <li><a href="#介绍">介绍</a></li>
-        <li><a href="#加入">如何加入</a></li>
+        <li><a href="html/server/ks-game.html#介绍">介绍</a></li>
+        <li><a href="html/server/ks-game.html#加入">如何加入</a></li>
       </ul>
     </nav>
   </aside>
@@ -61,7 +60,7 @@
         <p>
           <q>他们朝我扔整合包, 我拿整合包做服务端</q>
           <br>
-          一群人在网上疯狂寻找Minecraft整合包, 扔给 <a href="about-host.html">侃生电核2333</a> , 做出服务端后一起联机游玩。
+          一群人在网上疯狂寻找Minecraft整合包, 扔给 <a href="html/about-host.html">侃生电核2333</a> , 做出服务端后一起联机游玩。
           <br>
           但总是因为种种原因直接弃坑, 到现在也只有2个整合包/地图完结。
           <br>

--- a/html/server/ks-server.html
+++ b/html/server/ks-server.html
@@ -7,10 +7,10 @@
   <meta name="keywords" content="Ks-server, Ks服, Minecraft生电服">
   <meta name="description" content="Ks-server介绍">
   <meta name="author" content="侃生电核2333">
-  <base target="_self">
-  <link rel="icon" href="../resources/img/avatar-ksdh2333.png">
-  <link rel="stylesheet" href="../css/core/global.css">
-  <script defer src="../javascript/sidebar.js"></script>
+  <base target="_self" href="../../">
+  <link rel="icon" href="resources/img/avatar-ksdh2333.png">
+  <link rel="stylesheet" href="css/core/global.css">
+  <script defer src="javascript/sidebar.js"></script>
   <title>Ks-server Minecraft生电服 - 侃生电核2333</title>
 </head>
 
@@ -18,7 +18,7 @@
   <header>
     <nav class="header-nav">
       <div>
-        <a href="../index.html" title="首页"><img src="../resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
         <div>
           <strong>侃生电核2333</strong>
           <p>
@@ -28,29 +28,28 @@
       </div>
       <div>
         <ul>
-          <li><a href="../index.html">首页</a></li>
-          <li><a href="ks-server.html">生电服</a></li>
-          <li><a href="ks-game.html">游戏服</a></li>
-          <li><a href="useful-minecraftresources.html">实用资源</a></li>
-          <li><a href="useful-links.html">实用网页</a></li>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
         </ul>
       </div>
-      <a href="about-host.html" id="about-host">关于站主</a>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
     </nav>
   </header>
 
   <aside class="sidebar-nav">
     <div>
       <h2>下载整合包</h2>
-      <a href="ks-server/dowloads.html" title="下载用于游玩Ks-server的整合包">下载Ks-server整合包&gt;&gt;</a>
+      <a href="html/server/ks-server/dowloads.html" title="下载用于游玩Ks-server的整合包">下载Ks-server整合包&gt;&gt;</a>
     </div>
     <nav>
       <h2>导航</h2>
       <ul>
-        <li><a href="#介绍">介绍</a></li>
-        <li><a href="#插件/模组">插件/模组</a></li>
-        <li><a href="#规则">规则</a></li>
-        <li><a href="#加入">如何加入</a></li>
+        <li><a href="html/server/ks-server.html#介绍">介绍</a></li>
+        <li><a href="html/server/ks-server.html#插件/模组">插件/模组</a></li>
+        <li><a href="html/server/ks-server.html#规则">规则</a></li>
+        <li><a href="html/server/ks-server.html#加入">如何加入</a></li>
       </ul>
     </nav>
   </aside>
@@ -62,7 +61,7 @@
       <div>
         <h2 id="介绍">介绍</h2>
         <p>
-          一个 <strong>开在自己电脑上</strong> 时不时就会掉线重启的服务端, 还有可能被<a href="ks-game.html">Ks-game</a>影响。
+          一个 <strong>开在自己电脑上</strong> 时不时就会掉线重启的服务端, 还有可能被<a href="html/server/ks-game.html">Ks-game</a>影响。
         </p>
         <p>
           开服务端原本只为了使用<a href="https://docs.mcdreforged.com/zh-cn/latest/" target="_blank" title="MCDReforged说明文档">MCDReforged</a>的插件和<a href="https://papermc.io/software/velocity/" target="_blank" title="Velocity官网">Velocity</a>互通服的方便, 但是也可以用来联机。

--- a/html/server/ks-server/dowloads.html
+++ b/html/server/ks-server/dowloads.html
@@ -7,9 +7,9 @@
   <meta name="keywords" content="Ks-server, Ks服, Minecraft生电服, 整合包, 下载">
   <meta name="description" content="Ks-server整合包">
   <meta name="author" content="侃生电核2333">
-  <base target="_self">
-  <link rel="icon" href="../../resources/img/avatar-ksdh2333.png">
-  <link rel="stylesheet" href="../../css/core/global.css">
+  <base target="_self" href="../../../">
+  <link rel="icon" href="resources/img/avatar-ksdh2333.png">
+  <link rel="stylesheet" href="css/core/global.css">
   <title>Ks-server整合包下载 - 侃生电核2333</title>
 </head>
 
@@ -17,7 +17,7 @@
   <header>
     <nav class="header-nav">
       <div>
-        <a href="../../index.html" title="首页"><img src="../../resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
         <div>
           <strong>侃生电核2333</strong>
           <p>
@@ -27,24 +27,23 @@
       </div>
       <div>
         <ul>
-          <li><a href="../../index.html">首页</a></li>
-          <li><a href="../ks-server.html">生电服</a></li>
-          <li><a href="../ks-game.html">游戏服</a></li>
-          <li><a href="../useful-minecraftresources.html">实用资源</a></li>
-          <li><a href="../useful-links.html">实用网页</a></li>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
         </ul>
       </div>
-      <a href="../about-host.html" id="about-host">关于站主</a>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
     </nav>
   </header>
 
-  <a href="../ks-server.html" title="返回Ks-server" class="botton back floating">&lt;返回</a>
+  <a href="html/server/ks-server.html" title="返回Ks-server" class="botton back floating">&lt;返回</a>
 
   <main>
     <div class="center card-1">
-      <h1>下载用于游玩 <a href="../ks-server.html"><strong>Ks-server</strong></a> 的整合包</h1>
+      <h1>下载用于游玩 <a href="html/server/ks-server.html"><strong>Ks-server</strong></a> 的整合包</h1>
       <p>
-        <a href="../ks-server.html">Ks-server</a> 指定整合包
+        <a href="html/server/ks-server.html">Ks-server</a> 指定整合包
         <br>
         可以把自己熟悉的 config 覆盖包内的 config 文件夹以适配键位
       </p>
@@ -82,7 +81,7 @@
           </li>
         </ul>
       </details>
-      <a href="../../resources/modpacks/Ks-server.mrpack" title="下载Ks-server 2.2.0.mrpack" download="Ks-server 2.2.0.mrpack" class="botton floating">下载</a>
+      <a href="resources/modpacks/Ks-server.mrpack" title="下载Ks-server 2.2.0.mrpack" download="Ks-server 2.2.0.mrpack" class="botton floating">下载</a>
     </div>
   </main>
 

--- a/html/server/server-nav.html
+++ b/html/server/server-nav.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="zh-Hans-CN">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="keywords" content="Ks-server, Ks服, Ks-game, Minecraft生电服, Minecraft联机">
+  <meta name="description" content="侃生电核2333联机">
+  <meta name="author" content="侃生电核2333">
+  <base target="_self" href="../../">
+  <link rel="icon" href="resources/img/avatar-ksdh2333.png">
+  <link rel="stylesheet" href="css/core/global.css">
+  <script defer src="javascript/sidebar.js"></script>
+  <title>联机 Server - 侃生电核2333</title>
+</head>
+
+<body>
+  <header>
+    <nav class="header-nav">
+      <div>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <div>
+          <strong>侃生电核2333</strong>
+          <p>
+            一个Minecraft玩家
+          </p>
+        </div>
+      </div>
+      <div>
+        <ul>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
+        </ul>
+      </div>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
+    </nav>
+  </header>
+
+  <main>
+    <div class="center card-1">
+
+      <h1>Minecraft联机</h1>
+
+      <p>
+        联机玩 <em>Minecraft</em>
+      </p>
+    </div>
+    <div class="center card-1">
+      <h2>服务端联机</h2>
+      <p>
+        真会有人来吗?
+      </p>
+      <div class="card-4-parent">
+        <a href="html/server/ks-server.html" title="Ks-server" class="card-4 floating">
+          <img src="resources/img/ks-server-icon.png" width="64" height="64" alt="Ks服图标">
+
+          <h3>Ks-server</h3>
+
+          <p>
+            Minecraft Java版1.21生电服
+            <br>
+            致力于在最前期的基础发展最高的产量
+            <br>
+            点击查看详情&gt;&gt;
+          </p>
+        </a>
+        <a href="html/server/ks-game.html" title="ks-game" class="card-4 floating">
+          <img src="resources/img/ks-game-icon.png" width="64" height="64" alt="Ks-game图标">
+
+          <h3>Ks-game</h3>
+
+          <p>
+            Minecraft整合包/地图联机
+            <br>
+            不定期与好友联机游玩整合包/地图等
+            <br>
+            点击查看详情&gt;&gt;
+          </p>
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <hr>
+  <footer>
+    <p>
+      &copy; 2025 侃生电核2333 Ks-server介绍
+      <br>
+      页面由 侃生电核2333 设计
+      <br>
+      网页开源项目:<a href="https://github.com/ksdh2333/ksdh2333.github.io/" target="_blank">https://github.com/ksdh2333/ksdh2333.github.io/</a>
+    </p>
+  </footer>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="zh-Hans-CN">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,115 +12,130 @@
   <link rel="stylesheet" href="css/core/global.css">
   <title>侃生电核2333 - ksdh23333</title>
 </head>
+
 <body>
-<header>
-<nav class="header-nav">
-  <div>
-    <a href="index.html" title="首页" target="_self"><img src="resources/img/avatar-ksdh2333.png" width="72" height="72" alt="头像"></a>
-    <div>
-      <strong>侃生电核2333</strong>
+  <header>
+    <nav class="header-nav">
+      <div>
+        <a href="index.html" title="首页"><img src="resources/img/avatar-ksdh2333.png" width="128" height="128" alt="头像"></a>
+        <div>
+          <strong>侃生电核2333</strong>
+          <p>
+            一个Minecraft玩家
+          </p>
+        </div>
+      </div>
+      <div>
+        <ul>
+          <li><a href="index.html">首页</a></li>
+          <li><a href="html/server/server-nav.html">Minecraft联机</a></li>
+          <li><a href="html/minecraft-resources/minecraft-resources-nav.html">Minecraft资源</a></li>
+          <li><a href="html/knowledge-base/knowledge-base-nav.html">知识库</a></li>
+        </ul>
+      </div>
+      <a href="html/about-host.html" id="about-host">关于站主</a>
+    </nav>
+  </header>
+
+  <main>
+    <div class="center card-1">
+
+      <h1>侃生电核2333的个人主页</h1>
+
       <p>
-        一个Minecraft玩家
+        这里是Minecraft玩家<span>ksdh2333</span>的个人网站
+        <br>
+        这里有我的<span>相关账号</span>
+        <br>
+        我的<span>小服务器</span>介绍
+        <br>
+        以及整合了一些我个人常用的<span>网站链接</span>
+      </p>
+      <a href="html/about-host.html" target="_self" title="关于站主">关于</a>
+      <a href="https://space.bilibili.com/3493268878789144" target="_blank" title="Bilibili 侃生电核2333">B站空间</a>
+      <a href="https://github.com/ksdh2333/" target="_blank" title="Github ksdh2333">Github账号</a>
+    </div>
+
+    <div class="center card-1">
+
+      <h2>我的服务器</h2>
+
+      <p>
+        与其说是服务器, 更应该是用服务端联机
+      </p>
+      <div class="card-2-parent">
+        <a href="html/server/ks-server.html" title="Ks-server" class="card-3 floating">
+          <img src="resources/img/ks-server-icon.png" width="64" height="64" alt="Ks服图标">
+
+          <h3>Ks-server</h3>
+
+          <p>
+            Minecraft Java版1.21生电服
+            <br>
+            致力于在最前期的基础发展最高的产量
+            <br>
+            点击查看详情&gt;&gt;
+          </p>
+        </a>
+        <a href="html/server/ks-game.html" title="ks-game" class="card-3 floating">
+          <img src="resources/img/ks-game-icon.png" width="64" height="64" alt="Ks-game图标">
+
+          <h3>Ks-game</h3>
+
+          <p>
+            Minecraft整合包/地图联机
+            <br>
+            不定期与好友联机游玩整合包/地图等
+            <br>
+            点击查看详情&gt;&gt;
+          </p>
+        </a>
+      </div>
+    </div>
+
+    <div class="card-2-parent">
+      <a href="html/minecraft-resources/useful-minecraft-resources.html" class="card-2 floating">
+
+        <h2>Minecraft实用资源</h2>
+
+        <p>
+          辅助模组 红石材质包 光影
+          <br>
+          点击查看&gt;&gt;
+        </p>
+      </a>
+      <a href="html/minecraft-resources/useful-minecraft-links.html" class="card-2 floating">
+
+        <h2>Minecraft实用网站</h2>
+
+        <p>
+          中文Wiki 模组网站 种子工具
+          <br>
+          点击查看&gt;&gt;
+        </p>
+      </a>
+    </div>
+
+    <div class="center card-1">
+
+      <h2>与 侃生电核2333 联系</h2>
+
+      <p>
+        邮箱:<a href="mailto:ksdh2333@outlook.com/">ksdh2333@outlook.com</a>
       </p>
     </div>
-  </div>
-  <div>
-    <ul>
-      <li><a href="index.html" target="_self">首页</a></li>
-      <li><a href="html/ks-server.html" target="_self">生电服</a></li>
-      <li><a href="html/ks-game.html" target="_self">游戏服</a></li>
-      <li><a href="html/useful-minecraftresources.html" target="_self">实用资源</a></li>
-      <li><a href="html/useful-links.html" target="_self">实用网页</a></li>
-    </ul>
-  </div>
-  <a href="html/about-host.html" target="_self" id="about-host">关于站主</a>
-</nav>
-</header>
+  </main>
 
-<main>
-<div class="center card-1">
-  <h1>侃生电核2333的个人主页</h1>
-  <p>
-    这里是Minecraft玩家<span>ksdh2333</span>的个人网站
-    <br>
-    这里有我的<span>相关账号</span>
-    <br>
-    我的<span>小服务器</span>介绍
-    <br>
-    以及整合了一些我个人常用的<span>网站链接</span>
-  </p>
-  <a href="html/about-host.html" target="_self" title="关于站主">关于</a>
-  <a href="https://space.bilibili.com/3493268878789144" target="_blank" title="Bilibili 侃生电核2333">B站空间</a>
-  <a href="https://github.com/ksdh2333/" target="_blank" title="Github ksdh2333">Github账号</a>
-</div>
-
-<div class="center card-1">
-  <h2>我的服务器</h2>
-  <p>
-    与其说是服务器, 更应该是用服务端联机
-  </p>
-  <div class="card-2-parent">
-    <a href="html/ks-server.html" title="Ks-server" class="card-3 floating">
-      <img src="resources/img/ks-server-icon.png" width="64" height="64" alt="Ks服图标">
-      <h3>Ks-server</h3>
-      <p>
-        Minecraft Java版1.21生电服
-        <br>
-        致力于在最前期的基础发展最高的产量
-        <br>
-        点击查看详情&gt;&gt;
-      </p>
-    </a>
-    <a href="html/ks-game.html" title="ks-game" class="card-3 floating">
-      <img src="resources/img/ks-game-icon.png" width="64" height="64" alt="Ks-game图标">
-      <h3>Ks-game</h3>
-      <p>
-        Minecraft整合包/地图联机
-        <br>
-        不定期与好友联机游玩整合包/地图等
-        <br>
-        点击查看详情&gt;&gt;
-      </p>
-    </a>
-  </div>
-</div>
-
-<div class="card-2-parent">
-  <a href="html/useful-minecraftresources.html" class="card-2 floating">
-    <h2>Minecraft实用资源</h2>
+  <hr>
+  <footer>
     <p>
-      辅助模组 红石材质包 光影
+      &copy; 2025 侃生电核2333 个人主页
       <br>
-      点击查看&gt;&gt;
-    </p>
-  </a>
-  <a href="html/useful-links.html" class="card-2 floating">
-    <h2>Minecraft实用网站</h2>
-    <p>
-      中文Wiki 模组网站 种子工具
+      页面由 侃生电核2333 设计
       <br>
-      点击查看&gt;&gt;
+      网页开源项目:<a href="https://github.com/ksdh2333/ksdh2333.github.io/" target="_blank" class="footer">https://github.com/ksdh2333/ksdh2333.github.io/</a>
     </p>
-  </a>
-</div>
-
-<div class="center card-1">
-  <h2>与 侃生电核2333 联系</h2>
-  <p>
-    邮箱:<a href="mailto:ksdh2333@outlook.com/">ksdh2333@outlook.com</a>
-  </p>
-</div>
-</main>
-
-<hr>
-<footer>
-<p>
-  &copy; 2025 侃生电核2333 个人主页
-  <br>
-  页面由 侃生电核2333 设计
-  <br>
-  网页开源项目:<a href="https://github.com/ksdh2333/ksdh2333.github.io/" target="_blank" class="footer">https://github.com/ksdh2333/ksdh2333.github.io/</a>
-</p>
-</footer>
+  </footer>
 </body>
+
 </html>


### PR DESCRIPTION
页面:

1. `useful-minecraft-links.html` (原 `useful-links.html`) 与 `useful-minecraft-resources.html` (原 `useful-minecraftresources.html`) 分在 `minecraft-resources` 组, 新建组导航页 `minecraft-resources-nav.html`
2. `ks-server.html` 与其附属 `downloads.html` 和 `ks-game.html` 页面分在 `server` 组, 新建导航页 `server-nav.html`
3. `spyglass-usage.html` 与其附属 `spyglass-usage.md` 分在 `knowledge-base` 组, 新建导航页 `knowledge-base-nav.html` 
Closes #30 Closes #42

样式:

1. 添加 `.card-4` 与 `.card-4-parent` 用于纵向排列二级卡片